### PR TITLE
Exercise 1: Gwen Activities 

### DIFF
--- a/source/user/tutorial/ipython_tour.rst
+++ b/source/user/tutorial/ipython_tour.rst
@@ -27,7 +27,7 @@ A Jupyter notebook has four main areas:
     :width: 100%
     :alt: Annotated view of an Jupyter notebook upon loading
 
-Execute your Scenario in an Jupyter Notebook
+Jupyter Notebook Scenario Execution 
 --------------------------------------------
 1. Go to the Jupyter notebook
 2. Remove any old cyclus output files by: ``!rm tutorial.sqlite``

--- a/source/user/tutorial/ipython_tour.rst
+++ b/source/user/tutorial/ipython_tour.rst
@@ -1,8 +1,21 @@
-A Tour of the Cyclus User Interface with IPython Notebook
+Using Cyclus with Jupyter Notebook
 =========================================================
+For more ease of running Cyclus input files and managing the output 
+files, the **Jupyter Notebook** tool can be utilized. 
 
+Why is it useful?
+-----------------
 
-An IPython notebook has four main areas:
+A user can input the code required to run the simulation and analyze 
+its output in one **Jupyter Notebook** with clear descriptions.
+
+Here is a tutorial on how to get `Jupyter Notebook <https://jupyter.readthedocs.io/en/latest/install.html>`_ set up on your 
+computer. 
+
+Brief Introduction to Jupyter Notebook
+--------------------------------------
+
+A Jupyter notebook has four main areas:
 
 * A **Run** button that runs the cell you're in
 * A **Up and Down** buttons that move you up or down a cell
@@ -12,4 +25,26 @@ An IPython notebook has four main areas:
 .. image:: ipython_tour.png
     :align: center
     :width: 100%
-    :alt: Annotated view of an IPython notebook upon loading
+    :alt: Annotated view of an Jupyter notebook upon loading
+
+Execute your Scenario in an Jupyter Notebook
+--------------------------------------------
+1. Go to the Jupyter notebook
+2. Remove any old cyclus output files by: ``!rm tutorial.sqlite``
+3. Run CYCLUS by: ``!cyclus input.xml -o tutorial.sqlite``
+
+.. image:: cyclus_in_IP.png
+    :align: center
+    :alt: Running CYCLUS in an IPython Notebook
+
+Retrieve your Results for Analysis
+----------------------------------
+When your simulation has finished, a file of the name ``tutorial.sqlite`` will be in your file folder
+
+Backup: Files for Success
+++++++++++++++++++++++++++
+
+If your run did not succeed, you can retrieve these files to continue:
+
+* `Successful input file <http://cnergdata.engr.wisc.edu/cyclus/cyclist/tutorial/cycic-tutorial.xml>`_
+* `Successful output db file <http://cnergdata.engr.wisc.edu/cyclus/cyclist/tutorial/cycic-tutorial.sqlite>`_

--- a/source/user/tutorial/launch_cyclus.rst
+++ b/source/user/tutorial/launch_cyclus.rst
@@ -1,26 +1,27 @@
-Working with Cyclus in the Cloud
+Using Cyclus with the Cloud
 =================================
 
 Choosing Where to Run
 -----------------------
+For this tutorial, there are 2 options for places to run the Cyclus simulation. 
+1. Our cloud resource where Cyclus is installed. 
+2. A `Jupyter Notebook <http://fuelcycle.org/user/tutorial/ipython_tour.html>`_ 
+in the local machine where you have Cyclus installed. 
 
-The Cyclist user interface can be used to run simulations on your local
-machine, if you have |Cyclus| installed, or in an appropriately configured
-cloud resource.  The advantage of using a local machine is that you can
-control which archetypes are available.  The advantage of using a remote
-machine is that you don't have to install the entire |Cyclus| toolset on your
-local machine.
+The advantage of using your local machine is that you can determine which 
+version of Cyclus you want to use and if you wanted to include archetypes 
+that are not available on the cloud resource.    
 
-For today's tutorial, a cloud resource has been made available at
+For today's tutorial, the cloud resource has been made available at
 cycrun.fuelcycle.org.  This is the same resources that is used to run |Cyclus|
 from the |Cyclus| home page.
 
-Activity: Execute your Scenario in the Cloud
+Execute your Scenario in the Cloud
 ++++++++++++++++++++++++++++++++++++++++++++
 
-1. Find the your input file (.xml) on your computer
+1. Open the XML input file that you created in Exercise 1
 2. Go to the Server: http://cycrun.fuelcycle.org
-3. Copy and paste the file's information into the window
+3. Copy and paste the input file content into the window
 4. Click the "Submit" button
 5. This will launch a job and show you the "Job Id"
 
@@ -28,7 +29,7 @@ Activity: Execute your Scenario in the Cloud
     :align: center
     :alt: Job status is shown when executing in the cloud
 
-Activity: Retrieve your Results for Analysis
+Retrieve your Results for Analysis
 ++++++++++++++++++++++++++++++++++++++++++++++
 
 1. When your simulation in the cloud has finished, it will indicate in the
@@ -43,7 +44,7 @@ Activity: Retrieve your Results for Analysis
 Backup: Files for Success
 ++++++++++++++++++++++++++
 
-In case your run did not succeed, you can retrieve these files to continue:
+If your run did not succeed, you can retrieve these files to continue:
 
 * `Successful input file <http://cnergdata.engr.wisc.edu/cyclus/cyclist/tutorial/cycic-tutorial.xml>`_
 * `Successful output db file <http://cnergdata.engr.wisc.edu/cyclus/cyclist/tutorial/cycic-tutorial.sqlite>`_


### PR DESCRIPTION
This PR addresses https://github.com/arfc/cyclus.github.com/issues/3 with additional changes based on the suggestions made during the Cyclus tutorial developer call on Friday 14 Sept. 

There are a few more things that need to be implemented before the PR is closed: 
1) Move the ipynb_tour page to after the launch_cyclus page 
2) Link downloadable copies of the tutorial exercise 1 input and output files to both pages 
3) Delete the run_cyclus_native page