### PR TITLE
Fixed bib syntax to allow gh-preview

### DIFF
--- a/source/cep/cep-0018-1.bib
+++ b/source/cep/cep-0018-1.bib
@@ -81,22 +81,18 @@
 }
 
 @article{nagurney_supply_2002,
-title = "A supply chain network equilibrium model",
-journal = "Transportation Research Part E: Logistics and Transportation Review",
-volume = "38",
-number = "5",
-pages = "281 - 303",
-year = "2002",
-note = "",
-issn = "1366-5545",
-doi = "10.1016/S1366-5545(01)00020-5",
-url = "http://www.sciencedirect.com/science/article/pii/S1366554501000205",
-author = "Anna Nagurney and June Dong and Ding Zhang",
-keywords = "Supply chains",
-keywords = "Networks",
-keywords = "Equilibrium",
-keywords = "Variational inequalities",
-keywords = "Decentralized decision-making"
+title = {A supply chain network equilibrium model},
+journal = {Transportation Research Part E: Logistics and Transportation Review},
+volume = {38},
+number = {5},
+pages = {281 - 303},
+year = {2002},
+note = {},
+issn = {1366-5545},
+doi = {10.1016/S1366-5545(01)00020-5},
+url = {http://www.sciencedirect.com/science/article/pii/S1366554501000205},
+author = {Anna Nagurney and June Dong and Ding Zhang},
+keywords = {Supply chains;Networks;Equilibrium;Variational inequalities;Decentralized decision-making}
 }
 
 @ARTICLE{song_nash_2002, 

--- a/source/newsletters/pubsmay2018.bib
+++ b/source/newsletters/pubsmay2018.bib
@@ -11,6 +11,6 @@
     address = {Gainsville, Florida},
     title = {{Numerical Experiments For Testing Demand-Driven Deployment Algorithms.}},
     booktitle = {{American Nuclear Society 2018 National Student Conference}},
-    author = {Chee, Gwendolyn, Jin Whan Bae, and Kathryn D. Huff},
+    author = {Chee, Gwendolyn and Bae, Jin Whan and Huff, Kathryn D.},
     year = {2018}
 }


### PR DESCRIPTION
Modified some of the citation metadata to build gh-preview of html files. Should match what is in the cyclus/cyclus.github.com repo. 